### PR TITLE
feat: add UnboundPredicate::negate()

### DIFF
--- a/crates/iceberg/src/expr/mod.rs
+++ b/crates/iceberg/src/expr/mod.rs
@@ -64,3 +64,26 @@ impl Display for PredicateOperator {
         }
     }
 }
+
+impl PredicateOperator {
+
+    /// Returns the predicate that is the inverse of self
+    pub fn negate(self) -> PredicateOperator {
+        match self {
+            PredicateOperator::IsNull => PredicateOperator::NotNull,
+            PredicateOperator::NotNull => PredicateOperator::IsNull,
+            PredicateOperator::IsNan => PredicateOperator::NotNan,
+            PredicateOperator::NotNan => PredicateOperator::IsNan,
+            PredicateOperator::LessThan => PredicateOperator::GreaterThanOrEq,
+            PredicateOperator::LessThanOrEq => PredicateOperator::GreaterThan,
+            PredicateOperator::GreaterThan => PredicateOperator::LessThanOrEq,
+            PredicateOperator::GreaterThanOrEq => PredicateOperator::LessThan,
+            PredicateOperator::Eq => PredicateOperator::NotEq,
+            PredicateOperator::NotEq => PredicateOperator::Eq,
+            PredicateOperator::In => PredicateOperator::NotIn,
+            PredicateOperator::NotIn => PredicateOperator::In,
+            PredicateOperator::StartsWith => PredicateOperator::NotStartsWith,
+            PredicateOperator::NotStartsWith => PredicateOperator::StartsWith,
+        }
+    }
+}


### PR DESCRIPTION
Hi @liurenjie1024 - I've got an implementation of `UnboundPredicate::negate()`, which should help towards https://github.com/apache/iceberg-rust/issues/150 (expression rewriter to remove `NOT` operator). 

I've based this on `Expression::negate` from the Java implementation - defined in the Expression interface [here](https://github.com/apache/iceberg/blob/main/api/src/main/java/org/apache/iceberg/expressions/Expression.java#L63), and an example implementation for AND in the Java implementation [here](https://github.com/apache/iceberg/blob/main/api/src/main/java/org/apache/iceberg/expressions/And.java#L55).